### PR TITLE
Support for Laravel 11 (php8)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php": "^7.1|^8.0",
     "ext-intl": "*",
     "ext-mbstring": "*",
-    "illuminate/support": "^5.8|^6|^7|^8|^8.0|^9.0|^10.0|^11.0",
+    "illuminate/support": "^5.8|^6|^7|^8|^8.0|^9.0|^10.0|^11.0|^12.0",
     "umpirsky/country-list": "2.0.*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     }
   ],
   "require": {
-    "php": "^7.1 || ^8.0",
+    "php": "^7.1|^8.0",
     "ext-intl": "*",
     "ext-mbstring": "*",
-    "illuminate/support": "^5.8|^6|^7|^8",
+    "illuminate/support": "^5.8|^6|^7|^8|^8.0|^9.0|^10.0|^11.0",
     "umpirsky/country-list": "2.0.*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.1 || ^8.0",
     "ext-intl": "*",
     "ext-mbstring": "*",
     "illuminate/support": "^5.8|^6|^7|^8",


### PR DESCRIPTION
The package is fully ready for Laravel 11/12 with PHP 8, but the composer.json is saying otherwise.
With these two fixes in composer.json, the package is working in Laravel 11/12. 